### PR TITLE
Abc 25: nice text edit added to manage item

### DIFF
--- a/inventory/forms/__init__.py
+++ b/inventory/forms/__init__.py
@@ -5,3 +5,4 @@ from .image_upload_form import ImageUploadForm
 from .item_image_form import ItemImageForm
 from .image_associate_form import ImageAssociateForm
 from .image_associate_meta_form import ImageAssociateMetaForm
+from .label_form import LabelForm

--- a/inventory/forms/basic_item_form.py
+++ b/inventory/forms/basic_item_form.py
@@ -16,7 +16,7 @@ class BasicItemForm(ModelForm):
 
     description = CharField(
         required=False,
-        widget=Textarea(attrs={'id': 'user-tiny-mce'}))
+        widget=Textarea(attrs={'class': 'user-tiny-mce'}))
     step = IntegerField(widget=HiddenInput(), initial=0)
 
     class Meta:

--- a/inventory/forms/default_form_text.py
+++ b/inventory/forms/default_form_text.py
@@ -7,3 +7,7 @@ item_image_help = {
     'new_images': '''Upload 1 or many images from your computer.  Select
      many images using CONTROL or SHIFT in the file browser.  Adding images
      here will automatically link them to this item.'''}
+item_text_help = '''To create a new text label for this item, add text to the
+ "New Text" field below.  To create many text items, add each one and click
+ "Add & Keep Working" to get another field.  To delete a text item, remove the
+ text from the field and it will be deleted.'''

--- a/inventory/forms/label_form.py
+++ b/inventory/forms/label_form.py
@@ -1,0 +1,18 @@
+from django.forms import (
+    CharField,
+    ModelForm,
+    Textarea,
+)
+from inventory.models import ItemText
+
+
+class LabelForm(ModelForm):
+    required_css_class = 'required'
+    error_css_class = 'error'
+    text = CharField(
+        required=False,
+        widget=Textarea(attrs={'class': 'user-tiny-mce'}))
+
+    class Meta:
+        model = ItemText
+        fields = ['text', ]

--- a/inventory/forms/label_form.py
+++ b/inventory/forms/label_form.py
@@ -4,12 +4,21 @@ from django.forms import (
     Textarea,
 )
 from inventory.models import ItemText
+from inventory.forms.default_form_text import item_text_help
+from inventory.models import UserMessage
 
 
 class LabelForm(ModelForm):
     required_css_class = 'required'
     error_css_class = 'error'
     text = CharField(
+        help_text=UserMessage.objects.get_or_create(
+                view="LabelForm",
+                code="ITEM_TEXT_INSTRUCTIONS",
+                defaults={
+                    'summary': "Item Help Text",
+                    'description': item_text_help}
+                )[0].description,
         required=False,
         widget=Textarea(attrs={'class': 'user-tiny-mce'}))
 

--- a/inventory/templates/inventory/generic_wizard.tmpl
+++ b/inventory/templates/inventory/generic_wizard.tmpl
@@ -39,7 +39,7 @@
   <div class="col-sm-12 col-md-6 col-lg-5">
     {% if not first %}<input type="submit" name="back" value="<< Back" class="btn btn-primary" >{% endif %}
     {% if not last %}<input type="submit" name="next" value="Save & Continue >>" class="btn btn-primary" >{% endif %}
-    {% if add %}<input type="submit" name="add" value="Add & Keep Working " class="btn btn-primary" >{% endif %}
+    {% if add %}<input type="submit" name="add" value="Add & Keep Working" class="btn btn-primary" >{% endif %}
     <input type="submit" name="finish" value="Finish" class="btn btn-primary" >
     <input type="submit" name="cancel" value="Cancel" class="btn btn-light" >
   </div>

--- a/inventory/templates/inventory/generic_wizard.tmpl
+++ b/inventory/templates/inventory/generic_wizard.tmpl
@@ -39,6 +39,7 @@
   <div class="col-sm-12 col-md-6 col-lg-5">
     {% if not first %}<input type="submit" name="back" value="<< Back" class="btn btn-primary" >{% endif %}
     {% if not last %}<input type="submit" name="next" value="Save & Continue >>" class="btn btn-primary" >{% endif %}
+    {% if add %}<input type="submit" name="add" value="Add & Keep Working " class="btn btn-primary" >{% endif %}
     <input type="submit" name="finish" value="Finish" class="btn btn-primary" >
     <input type="submit" name="cancel" value="Cancel" class="btn btn-light" >
   </div>

--- a/inventory/tests/test_make_item.py
+++ b/inventory/tests/test_make_item.py
@@ -5,6 +5,7 @@ from inventory.tests.factories import (
     CategoryFactory,
     DispositionFactory,
     ItemFactory,
+    ItemTextFactory,
     TagFactory,
     UserFactory
 )
@@ -16,7 +17,10 @@ from datetime import (
     date,
     timedelta,
 )
-from inventory.models import Item
+from inventory.models import (
+    Item,
+    ItemText,
+)
 
 
 class TestMakeItem(TestCase):
@@ -33,6 +37,7 @@ class TestMakeItem(TestCase):
             'notes': "new notes",
             'tags': (new_tag.pk, other_new_tag.pk),
             'connections': (self.item.pk, ),
+            'text': "",
         }
 
     def get_physical(self):
@@ -189,6 +194,11 @@ class TestMakeItem(TestCase):
         self.assertNotContains(response, "Save & Continue >>")
         self.assertContains(response, "Further Details")
         self.assertContains(response, self.item_id % self.item.pk, html=True)
+        self.assertContains(
+            response,
+            '<textarea name="text" cols="40" rows="10" class="user-tiny-mce"' +
+            'id="id_text">\n</textarea>',
+            html=True)
 
     def test_post_physical_create_finish(self):
         login_as(self.user, self)
@@ -201,6 +211,7 @@ class TestMakeItem(TestCase):
         self.assertContains(response, "if (row.id == %d) {" % (self.item.pk))
 
     def test_post_physical_edit_save_and_continue(self):
+        label = ItemTextFactory(item=self.item)
         login_as(self.user, self)
         physical = self.get_physical()
         physical['date_acquired'] = date.today()
@@ -213,6 +224,19 @@ class TestMakeItem(TestCase):
         self.assertNotContains(response, "Save & Continue >>")
         self.assertContains(response, "Further Details")
         self.assertContains(response, self.item_id % self.item.pk, html=True)
+        self.assertContains(
+            response,
+            '<textarea name="text" cols="40" rows="10" class="user-tiny-mce"' +
+            'id="id_text">\n</textarea>',
+            html=True)
+        self.assertContains(
+            response,
+            ('<textarea name="%d-text" cols="40" rows="10" ' +
+             'class="user-tiny-mce" id="id_%d-text">%s</textarea>') % (
+                label.pk,
+                label.pk,
+                label.text),
+            html=True)
 
     def test_post_physical_back(self):
         login_as(self.user, self)
@@ -236,6 +260,7 @@ class TestMakeItem(TestCase):
             response,
             "Updated Item: %s" % self.item.title)
         self.assertContains(response, "if (row.id == %d) {" % self.item.pk)
+        self.assertNotContains
 
     def test_post_physical_gone_before_it_came(self):
         login_as(self.user, self)
@@ -296,10 +321,30 @@ class TestMakeItem(TestCase):
         further = self.get_further()
         further['finish'] = "Finish"
         response = self.client.post(self.url, data=further, follow=True)
+        self.assertRedirects(response, "%s?changed_id=%s" % (
+            reverse("items_list", urlconf="inventory.urls"),
+            self.item.pk))
         self.assertContains(
             response,
             "Created new Item: %s" % self.item.title)
         self.assertContains(response, "if (row.id == %d) {" % (self.item.pk))
+        self.assertNotContains(response, "Text:")
+
+    def test_post_further_create_text(self):
+        login_as(self.user, self)
+        further = self.get_further()
+        further["text"] = "New text for %d" % self.item.pk
+        further['finish'] = "Finish"
+        response = self.client.post(self.url, data=further, follow=True)
+        self.assertRedirects(response, "%s?changed_id=%s" % (
+            reverse("items_list", urlconf="inventory.urls"),
+            self.item.pk))
+        self.assertContains(
+            response,
+            "Created new Item: %s" % self.item.title)
+        self.assertContains(response, "if (row.id == %d) {" % (self.item.pk))
+        self.assertContains(response, "<i>Text 1:</i>&nbsp;&nbsp;%s<br>" % (
+            further["text"]))
 
     def test_post_further_edit_finish(self):
         login_as(self.user, self)
@@ -307,10 +352,33 @@ class TestMakeItem(TestCase):
         further['date_deaccession'] = date.today() - timedelta(days=1)
         further['finish'] = "Finish"
         response = self.client.post(self.edit_url, data=further, follow=True)
+        self.assertRedirects(response, "%s?changed_id=%s" % (
+            reverse("items_list", urlconf="inventory.urls"),
+            self.item.pk))
         self.assertContains(
             response,
             "Updated Item: %s" % self.item.title)
         self.assertContains(response, "if (row.id == %d) {" % self.item.pk)
+        self.assertNotContains(response, "Text:")
+
+    def test_post_further_edit_text(self):
+        label = ItemTextFactory(item=self.item)
+        login_as(self.user, self)
+        further = self.get_further()
+        further['date_deaccession'] = date.today() - timedelta(days=1)
+        further['%d-text' % label.pk] = "edited text for pk %d" % label.pk
+        further['finish'] = "Finish"
+        response = self.client.post(self.edit_url, data=further, follow=True)
+        self.assertRedirects(response, "%s?changed_id=%s" % (
+            reverse("items_list", urlconf="inventory.urls"),
+            self.item.pk))
+        self.assertContains(
+            response,
+            "Updated Item: %s" % self.item.title)
+        self.assertContains(response, "if (row.id == %d) {" % self.item.pk)
+        self.assertContains(response, "<i>Text 1:</i>&nbsp;&nbsp;%s<br>" % (
+            further['%d-text' % label.pk]))
+        self.assertNotContains(response, "<i>Text 2:</i>")
 
     def test_post_further_back(self):
         login_as(self.user, self)
@@ -354,3 +422,53 @@ class TestMakeItem(TestCase):
 
         self.assertRedirects(response,
                              reverse('items_list', urlconf='inventory.urls'))
+
+    def test_post_further_add_text(self):
+        login_as(self.user, self)
+        further = self.get_further()
+        further["text"] = "New text for %d" % self.item.pk
+        further['add'] = "Add & Keep Working"
+        response = self.client.post(self.url, data=further, follow=True)
+        label = ItemText.objects.get(text=further["text"])
+        self.assertContains(response, "Further Details")
+        self.assertContains(
+            response,
+            "Created new text: %s" % further["text"])
+        self.assertContains(
+            response,
+            ('<textarea name="%d-text" cols="40" rows="10" ' +
+             'class="user-tiny-mce" id="id_%d-text">%s</textarea>') % (
+                label.pk,
+                label.pk,
+                label.text),
+            html=True)
+        self.assertContains(
+            response,
+            '<textarea name="text" cols="40" rows="10" class="user-tiny-mce"' +
+            'id="id_text">\n</textarea>',
+            html=True)
+
+    def test_post_further_delete_text(self):
+        label = ItemTextFactory(item=self.item)
+        login_as(self.user, self)
+        further = self.get_further()
+        further['%d-text' % label.pk] = ""
+        further['add'] = "Add & Keep Working"
+        response = self.client.post(self.url, data=further, follow=True)
+        self.assertContains(response, "Further Details")
+        self.assertContains(
+            response,
+            "Deleted a text item")
+        self.assertNotContains(
+            response,
+            ('<textarea name="%d-text" cols="40" rows="10" ' +
+             'class="user-tiny-mce" id="id_%d-text">%s</textarea>') % (
+                label.pk,
+                label.pk,
+                label.text),
+            html=True)
+        self.assertContains(
+            response,
+            '<textarea name="text" cols="40" rows="10" class="user-tiny-mce"' +
+            'id="id_text">\n</textarea>',
+            html=True)

--- a/inventory/views/generic_wizard.py
+++ b/inventory/views/generic_wizard.py
@@ -79,8 +79,8 @@ class GenericWizard(View):
             messages.success(request, "The last update was canceled.")
             return HttpResponseRedirect(self.return_url)
 
-        if 'next' in list(request.POST.keys()) or (
-                'finish' in list(request.POST.keys())):
+        if 'next' in list(request.POST.keys()) or 'finish' in list(
+                request.POST.keys()) or 'add' in list(request.POST.keys()):
             all_valid = True
             self.current_form_set = self.form_sets[self.step]
             if not self.current_form_set['the_form']:
@@ -100,6 +100,9 @@ class GenericWizard(View):
             self.finish_valid_form(request)
             if 'finish' in list(request.POST.keys()):
                 return HttpResponseRedirect(self.finish(request))
+            if 'add' in list(request.POST.keys()):
+                self.step = self.step - 1
+                self.current_form_set = self.form_sets[self.step]
         elif 'back' in list(request.POST.keys()):
             self.make_back_forms(request)
         else:

--- a/inventory/views/make_item_wizard.py
+++ b/inventory/views/make_item_wizard.py
@@ -75,6 +75,9 @@ class MakeItemWizard(GenericWizard):
                 if len(form.cleaned_data["text"]) == 0:
                     label = form.save(commit=False)
                     label.delete()
+                    messages.success(
+                        request,
+                        "Deleted a text item")
                 else:
                     form.save()
             if self.forms[-1].cleaned_data["text"] and len(

--- a/templates/tiny-mce-user-settings.tmpl
+++ b/templates/tiny-mce-user-settings.tmpl
@@ -1,11 +1,11 @@
 tinymce.init({
-  selector: 'textarea#user-tiny-mce',
+  selector: '.user-tiny-mce',
   plugins: 'paste searchreplace autolink directionality visualblocks visualchars fullscreen link charmap hr insertdatetime advlist lists wordcount textpattern noneditable help charmap quickbars emoticons',
   toolbar: 'undo redo | bold italic underline | outdent indent |  numlist bullist | charmap emoticons | link ',
   menubar: '',
   toolbar_sticky: true,
   branding: false,
-  height: 400,
+  height: 300,
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3',
   quickbars_insert_toolbar: '',
   noneditable_noneditable_class: "mceNonEditable",


### PR DESCRIPTION
On the last screen of the make item wizard a user can now:
- edit any existing text
- add more text entries, and keep adding using "Add & Keep Working"
- delete entries by deleting the text
